### PR TITLE
Add dnsmasq routing handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,13 @@ Options:
                                  Allowed values are: tcp, http, hybrid.
                                  Default value is: hybrid.
   -r|--routing <ROUTING>         Routing method
-                                 Allowed values are: hosts, windivert.
+                                 Allowed values are: hosts, windivert, dnsmasq.
                                  Default value is: windivert.
   -?|-h|--help                   Show help information.
 
 Environment variables:
   KRP_HOSTS                       Override path to hosts file
+  KRP_DNSMASQ_OVERRIDE            Override path to dnsmasq override configuration
 ```
 
 ### Routing methods
@@ -153,6 +154,16 @@ Environment variables:
 
 > [!NOTE]
 > WinDiverts installs as an ephemeral windows driver service at runtime. Once stopped, it's automatically removed.
+
+#### `dnsmasq`
+
+1. Writes endpoint mappings to a dnsmasq configuration override (default: `/run/dnsmasq/krp.override.conf`).
+2. Each endpoint hostname is written as an `address` directive pointing to its assigned loopback IP (e.g., `address=/myapp.local/127.0.0.2`).
+3. The override file is ephemeral; remove `krp` or its file to discard the entries.
+
+**Requirements**
+- dnsmasq must already be installed and configured to read override files (e.g., `--conf-dir=/run/dnsmasq`)
+- Write access to the configured override directory.
 
 ### Forwarders available
 

--- a/src/Krp/DependencyInjection/KubernetesForwarderBuilderExtensions.cs
+++ b/src/Krp/DependencyInjection/KubernetesForwarderBuilderExtensions.cs
@@ -125,12 +125,18 @@ public static class KubernetesBuilderExtension
                 var hostsPath = Environment.GetEnvironmentVariable("KRP_HOSTS") ?? (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                     ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), @"drivers\etc\hosts")
                     : "/etc/hosts");
-                
+
                 builder.Services.AddSingleton<IDnsHandler, DnsHostsHandler>();
                 builder.Services.Configure<DnsHostsOptions>(o => o.Path = hostsPath);
                 break;
             case DnsOptions.WinDivert:
                 builder.Services.AddSingleton<IDnsHandler, DnsWinDivertHandler>();
+                break;
+            case DnsOptions.DnsMasq:
+                var dnsMasqOverridePath = Environment.GetEnvironmentVariable("KRP_DNSMASQ_OVERRIDE") ?? "/run/dnsmasq/krp.override.conf";
+
+                builder.Services.AddSingleton<IDnsHandler, DnsMasqHandler>();
+                builder.Services.Configure<DnsMasqOptions>(o => o.OverridePath = dnsMasqOverridePath);
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(routing), routing, $"Invalid value for {nameof(DnsOptions)}");

--- a/src/Krp/Dns/DnsMasqHandler.cs
+++ b/src/Krp/Dns/DnsMasqHandler.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Krp.Dns;
+
+/// <summary>
+/// Writes endpoint mappings to a dnsmasq configuration override.
+/// <para>
+/// Each hostname is written as an <c>address</c> directive pointing to the
+/// assigned loopback IP. The override file is placed in a run-time directory so
+/// it remains ephemeral.
+/// </para>
+/// </summary>
+public class DnsMasqHandler : IDnsHandler
+{
+    private readonly DnsMasqOptions _options;
+    private readonly ILogger<DnsMasqHandler> _logger;
+
+    public DnsMasqHandler(IOptions<DnsMasqOptions> options, ILogger<DnsMasqHandler> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task RunAsync(CancellationToken stoppingToken)
+    {
+        await Task.CompletedTask;
+    }
+
+    public async Task UpdateAsync(List<string> hostnames)
+    {
+        try
+        {
+            var configLines = hostnames
+                .Select(line => line.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+                .Where(parts => parts.Length == 2)
+                .Select(parts => $"address=/{parts[1]}/{parts[0]}")
+                .ToList();
+
+            var directory = Path.GetDirectoryName(_options.OverridePath);
+            if (string.IsNullOrEmpty(directory))
+            {
+                _logger.LogError("dnsmasq override path is invalid: {path}", _options.OverridePath);
+                return;
+            }
+
+            Directory.CreateDirectory(directory);
+
+            var lines = new List<string>
+            {
+                "# Managed by krp",
+                "# Generated dnsmasq overrides for loopback routing.",
+            };
+
+            lines.AddRange(configLines);
+
+            if (File.Exists(_options.OverridePath))
+            {
+                var existing = await File.ReadAllLinesAsync(_options.OverridePath);
+                if (existing.SequenceEqual(lines))
+                {
+                    _logger.LogInformation("Skipped updating DNS due to no changes in dnsmasq override file");
+                    return;
+                }
+            }
+
+            await File.WriteAllLinesAsync(_options.OverridePath, lines);
+            _logger.LogInformation("Successfully updated dnsmasq override ({count} entries)", configLines.Count);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error when updating dnsmasq override file");
+            throw;
+        }
+    }
+}

--- a/src/Krp/Dns/DnsMasqOptions.cs
+++ b/src/Krp/Dns/DnsMasqOptions.cs
@@ -1,0 +1,9 @@
+namespace Krp.Dns;
+
+public class DnsMasqOptions
+{
+    /// <summary>
+    /// Path to the dnsmasq override configuration file.
+    /// </summary>
+    public string OverridePath { get; set; } = "/run/dnsmasq/krp.override.conf";
+}

--- a/src/Krp/Dns/DnsOptions.cs
+++ b/src/Krp/Dns/DnsOptions.cs
@@ -11,4 +11,9 @@ public enum DnsOptions
     /// Use WinDivert for DNS routing.
     /// </summary>
     WinDivert,
+
+    /// <summary>
+    /// Use dnsmasq for DNS routing.
+    /// </summary>
+    DnsMasq,
 }

--- a/src/dotnet-krp/Commands/RootCommand.cs
+++ b/src/dotnet-krp/Commands/RootCommand.cs
@@ -34,13 +34,13 @@ public class RootCommand
 
     [Option("--no-ui", Description = "Disable terminal UI")]
     public bool NoTerminalUi { get; init; } = false;
-    
+
     [Option("--forwarder|-f <FORWARDER>", Description = "Forwarding method")]
     [AllowedValues("tcp", "http", "hybrid", IgnoreCase = true)]
     public string Forwarder { get; init; } = "hybrid";
 
     [Option("--routing|-r <ROUTING>", Description = "Routing method")]
-    [AllowedValues("hosts", "windivert", IgnoreCase = true)]
+    [AllowedValues("hosts", "windivert", "dnsmasq", IgnoreCase = true)]
     public string Routing { get; init; }
 
     public RootCommand()
@@ -76,6 +76,9 @@ public class RootCommand
                 break;
             case "windivert":
                 builder.UseRouting(DnsOptions.WinDivert);
+                break;
+            case "dnsmasq":
+                builder.UseRouting(DnsOptions.DnsMasq);
                 break;
         }
         switch (Forwarder)


### PR DESCRIPTION
Add experimental support for dnsmasq routing handler.

- Writes loopback mappings to an override file (does not require admin).
- Add new `dnsmasq` routing option with configurable override path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69308771cd7883238822bbcfb1ab541d)